### PR TITLE
fix(web): apollo ssr absolute url issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ temp
 coverage
  .turbo
 .turbo
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*

--- a/packages/web/src/lib/apollo/client.ts
+++ b/packages/web/src/lib/apollo/client.ts
@@ -7,7 +7,7 @@ export const isBrowser = () => typeof window !== "undefined"
 
 let apolloClient: ApolloClient<NormalizedCacheObject> | null = null
 
-const httpLink = createHttpLink({ uri: isBrowser() ? API_URL : "/api/graphql" })
+const httpLink = createHttpLink({ uri: !isBrowser() ? API_URL : "/api/graphql" })
 
 function createApolloClient(initialState: null | Record<string, any>) {
   return new ApolloClient({

--- a/packages/web/src/lib/apollo/client.ts
+++ b/packages/web/src/lib/apollo/client.ts
@@ -1,12 +1,13 @@
 import * as React from "react"
 import { ApolloClient, createHttpLink, InMemoryCache, NormalizedCacheObject } from "@apollo/client"
 import { mergeDeep } from "@apollo/client/utilities"
+import { API_URL } from "lib/config"
 
 export const isBrowser = () => typeof window !== "undefined"
 
 let apolloClient: ApolloClient<NormalizedCacheObject> | null = null
 
-const httpLink = createHttpLink({ uri: "/api/graphql" })
+const httpLink = createHttpLink({ uri: isBrowser() ? API_URL : "/api/graphql" })
 
 function createApolloClient(initialState: null | Record<string, any>) {
   return new ApolloClient({


### PR DESCRIPTION

Fixed issue where Apollo was unusable server side due to the`/api/graphql` endpoint being called rather than the absolute url. 

Also updated the `.gitignore` to prevent inclusion of the local yarn logs. [Reference](https://www.toptal.com/developers/gitignore/api/node) 

To replicate error on `main`/`develop`, just try to make a SSR Apollo query or mutation within the `index.tsx` or within a `/api/...` route.

```ts
export async function getServerSideProps() {
  const apolloClient = initializeApollo({})

  await apolloClient.query({
    query: MeDocument,
  })

  return {
    props: {},
  }
}
```



